### PR TITLE
Fix: Update env command

### DIFF
--- a/includes/builtins.h
+++ b/includes/builtins.h
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 23:01:22 by vwildner          #+#    #+#             */
-/*   Updated: 2022/04/21 15:57:03 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/04/25 19:21:39 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ typedef struct s_command {
 typedef int	t_dispatcher(t_command *cmd);
 
 /* internal functions */
-int			env(void);
+int			env(char *envp[]);
 int			export(char *arg, char *envp[]);
 
 /* public interface */

--- a/libs/builtins/builtins.c
+++ b/libs/builtins/builtins.c
@@ -8,6 +8,6 @@ int builtins_echo(t_command *cmd)
 
 int builtins_env(t_command *cmd)
 {
-	env();
+	env(cmd->envp);
 	return (0);
 }

--- a/libs/builtins/env.c
+++ b/libs/builtins/env.c
@@ -1,13 +1,13 @@
 #include "../../includes/builtins.h"
 
-int	env(void)
+int	env(char *envp[])
 {
 	int	i;
 
 	i = -1;
-	while (__environ[++i])
+	while (envp[++i])
 	{
-		write(STDOUT_FILENO, __environ[i], ft_strlen(__environ[i]));
+		write(STDOUT_FILENO, envp[i], ft_strlen(envp[i]));
 		write(STDOUT_FILENO, "\n", 1);
 	}
 	return (0);

--- a/tests/test_env.c
+++ b/tests/test_env.c
@@ -1,7 +1,15 @@
 #include "../includes/builtins.h"
 
-int main(void)
+int main(int argc, char *argv[], char *envp[])
 {
-	env();
+	t_command cmd;
+
+	cmd = (t_command) {
+		.argc = argc,
+		.argv = argv,
+		.envp = envp
+	};
+
+	builtins_env(&cmd);
 	return (0);
 }


### PR DESCRIPTION
The original env implementation is using the global `__environ` setting, but our program has a high level handler `cmd->envp` that should be used instead. Also another reason to use `envp` instead is the fact that it can be used as a mutable object and `__environ` should not.