### PR TITLE
Feature: Path executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,20 @@
 #    By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/19 22:38:45 by itaureli          #+#    #+#              #
-#    Updated: 2022/05/07 21:52:40 by vwildner         ###   ########.fr        #
+#    Updated: 2022/05/08 02:40:26 by vwildner         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-SRC		=	minishell.c readline.c wip_lexer.c print_error.c execute.c utils.c
+SRC		= readline.c wip_lexer.c print_error.c execute.c utils.c execute_system.c
+
+SRC_MAIN = $(SRC)
+SRC_MAIN += minishell.c
 
 SRC_PATH = ./src
 
-SRCS = $(addprefix $(SRC_PATH)/,$(SRC))
+SRCS_NO_ENTRY = $(addprefix $(SRC_PATH)/,$(SRC))
+
+SRCS = $(addprefix $(SRC_PATH)/,$(SRC_MAIN))
 
 OBJECTS		=	${SRCS:.c=.o}
 
@@ -108,7 +113,7 @@ $(BUILTINS_OBJECTS_PATH)/%.o: $(BUILTINS_SOURCES_PATH)/%.c $(BUILTINS_HEADER)
 test:
 	@$(CC) tests/test_unit.c \
 	libs/libft/*.c libs/builtins/*.c \
-	src/wip_lexer.c src/readline.c src/print_error.c src/signal.c src/execute.c \
+	$(SRCS_NO_ENTRY) \
 	-lreadline -lrt -lm \
 	-o test_unit && ./test_unit
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@
 #    By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/19 22:38:45 by itaureli          #+#    #+#              #
-#    Updated: 2022/05/07 20:52:18 by vwildner         ###   ########.fr        #
+#    Updated: 2022/05/07 21:52:40 by vwildner         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-SRC		=	minishell.c readline.c wip_lexer.c print_error.c execute.c
+SRC		=	minishell.c readline.c wip_lexer.c print_error.c execute.c utils.c
 
 SRC_PATH = ./src
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/30 17:04:35 by mfrasson          #+#    #+#             */
-/*   Updated: 2022/05/07 21:53:44 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/08 01:02:32 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,5 +49,6 @@ void	signal_handler(int signal_number);
 int		execute(t_command *cmd);
 
 void	atexit_clean(void *data);
+char	*get_abspath(char *cmd, const char *path);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/30 17:04:35 by mfrasson          #+#    #+#             */
-/*   Updated: 2022/05/06 23:27:56 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/07 21:53:44 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,5 +47,7 @@ int		pwd(void);
 void	signal_handler(int signal_number);
 
 int		execute(t_command *cmd);
+
+void	atexit_clean(void *data);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/30 17:04:35 by mfrasson          #+#    #+#             */
-/*   Updated: 2022/05/08 01:02:32 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/08 02:26:18 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,7 @@ char	**parse_input(char *input_text);
 int		pwd(void);
 void	signal_handler(int signal_number);
 
+int		system_exec(t_command *cmd);
 int		execute(t_command *cmd);
 
 void	atexit_clean(void *data);

--- a/libs/builtins/builtins.c
+++ b/libs/builtins/builtins.c
@@ -24,6 +24,10 @@ int	builtins_cd(t_command *cmd)
 
 int	builtins_exit(t_command *cmd)
 {
+	if (cmd->argc > 1)
+		exit(ft_atoi(cmd->argv[1]));
+	else
+		exit(0);
 	return (0);
 }
 

--- a/libs/builtins/dispatcher.c
+++ b/libs/builtins/dispatcher.c
@@ -2,6 +2,7 @@
 
 static int	builtins_none(t_command *cmd)
 {
+	(void)cmd;
 	return (1);
 }
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -4,7 +4,7 @@
 # Usage: ./run_test.sh <test_name>
 
 cc tests/test_$1.c \
-  libs/libft/*.c libs/builtins/*.c src/wip_lexer.c src/readline.c src/print_error.c src/signal.c src/execute.c\
+  libs/libft/*.c libs/builtins/*.c $(find src/ -type f \( -iname "*.c" ! -iname "minishell*" \)) \
   -lreadline -lrt -lm \
   -o test_$1 \
     && ./test_$1 \

--- a/src/execute.c
+++ b/src/execute.c
@@ -6,13 +6,11 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/04 17:58:19 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/08 02:15:50 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/08 02:28:07 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
-#include "../includes/builtins.h"
-#include <fcntl.h>
 
 //static t_command	*get_command(void)
 //{
@@ -60,73 +58,6 @@ static int	try_builtins_exec(t_command *cmd)
 	refresh_builtins(cmd);
 	status = run(cmd);
 	return (status);
-}
-
-char	**to_array(t_list **list)
-{
-	char	**array;
-	t_list	*tmp;
-	int		i;
-	int		size;
-
-	size = 0;
-	i = 0;
-	tmp = *list;
-	while (tmp)
-	{
-		tmp = tmp->next;
-		size++;
-	}
-	array = (char **)malloc(sizeof(char *) * (size + 1));
-	tmp = *list;
-	while (tmp)
-	{
-		array[i] = tmp->content;
-		tmp = tmp->next;
-		i++;
-	}
-	return (array);
-}
-
-char	*solve_absolute_path(t_command *cmd)
-{
-	char	*first_arg;
-	char	*all_paths;
-
-	first_arg = cmd->argv[0];
-	if (*first_arg == '/' || *first_arg == '.')
-		return (first_arg);
-	all_paths = ms_getenv(cmd->envp, "PATH");
-	return (get_abspath(first_arg, all_paths));
-}
-
-int	system_exec(t_command *cmd)
-{
-	pid_t		pid;
-	int			status;
-	char		*abspath;
-	char		**compat_envp;
-
-	pid = fork();
-	if (pid == 0)
-	{
-		compat_envp = to_array(cmd->envp);
-		abspath = solve_absolute_path(cmd);
-		if (execve(abspath, cmd->argv, compat_envp) == -1)
-			perror("Command not found");
-		free(compat_envp);
-		free(abspath);
-		exit(EXIT_FAILURE);
-	}
-	else if (pid < 0)
-		return (0);
-	else
-	{
-		waitpid(pid, &status, WUNTRACED);
-		while (!WIFEXITED(status) && !WIFSIGNALED(status))
-			waitpid(pid, &status, WUNTRACED);
-	}
-	return (1);
 }
 
 int	execute(t_command *cmd)

--- a/src/execute_system.c
+++ b/src/execute_system.c
@@ -1,0 +1,80 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   execute_system.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/08 02:27:44 by vwildner          #+#    #+#             */
+/*   Updated: 2022/05/08 02:28:03 by vwildner         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+char	**to_array(t_list **list)
+{
+	char	**array;
+	t_list	*tmp;
+	int		i;
+	int		size;
+
+	size = 0;
+	i = 0;
+	tmp = *list;
+	while (tmp)
+	{
+		tmp = tmp->next;
+		size++;
+	}
+	array = (char **)malloc(sizeof(char *) * (size + 1));
+	tmp = *list;
+	while (tmp)
+	{
+		array[i] = tmp->content;
+		tmp = tmp->next;
+		i++;
+	}
+	return (array);
+}
+
+char	*solve_absolute_path(t_command *cmd)
+{
+	char	*first_arg;
+	char	*all_paths;
+
+	first_arg = cmd->argv[0];
+	if (*first_arg == '/' || *first_arg == '.')
+		return (first_arg);
+	all_paths = ms_getenv(cmd->envp, "PATH");
+	return (get_abspath(first_arg, all_paths));
+}
+
+int	system_exec(t_command *cmd)
+{
+	pid_t		pid;
+	int			status;
+	char		*abspath;
+	char		**compat_envp;
+
+	pid = fork();
+	if (pid == 0)
+	{
+		compat_envp = to_array(cmd->envp);
+		abspath = solve_absolute_path(cmd);
+		if (execve(abspath, cmd->argv, compat_envp) == -1)
+			perror("Command not found");
+		free(compat_envp);
+		free(abspath);
+		exit(EXIT_FAILURE);
+	}
+	else if (pid < 0)
+		return (0);
+	else
+	{
+		waitpid(pid, &status, WUNTRACED);
+		while (!WIFEXITED(status) && !WIFSIGNALED(status))
+			waitpid(pid, &status, WUNTRACED);
+	}
+	return (1);
+}

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/19 23:07:33 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/07 05:53:00 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/07 21:54:30 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,6 +86,7 @@ int	main(int argc, char *argv[], char *envp[])
 	}
 	signal(SIGQUIT, SIG_IGN);
 	cmd = init_builtins(envp);
+	atexit_clean(cmd);
 	status = 1;
 	while (status)
 	{
@@ -95,6 +96,5 @@ int	main(int argc, char *argv[], char *envp[])
 		expand_args(cmd);
 		status = execute(cmd);
 	}
-	free(cmd);
 	return (0);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/16 18:54:55 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/07 21:53:57 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/07 22:23:51 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,9 +19,9 @@ static void	clean(void)
 	atexit_clean(NULL);
 }
 
-void		atexit_clean(void *data)
+void	atexit_clean(void *data)
 {
-	static void *static_ptr;
+	static void	*static_ptr;
 
 	if (data)
 	{

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   utils.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/04/16 18:54:55 by itaureli          #+#    #+#             */
+/*   Updated: 2022/05/07 21:53:57 by vwildner         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+void		atexit_clean(void *data);
+
+static void	clean(void)
+{
+	atexit_clean(NULL);
+}
+
+void		atexit_clean(void *data)
+{
+	static void *static_ptr;
+
+	if (data)
+	{
+		static_ptr = data;
+		atexit(clean);
+	}
+	else
+		free(static_ptr);
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/16 18:54:55 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/07 22:23:51 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/08 00:45:51 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,4 +30,52 @@ void	atexit_clean(void *data)
 	}
 	else
 		free(static_ptr);
+}
+
+char	*help_slash_merge(char const *origin, char const *other)
+{
+	char	*merged;
+	char	*tmp;
+
+	if (!origin || !other)
+		return (NULL);
+	tmp = malloc(ft_strlen(origin) + ft_strlen(other) + 2);
+	if (!tmp)
+		return (NULL);
+	merged = tmp;
+	while (*origin)
+		*tmp++ = *origin++;
+	*tmp++ = '/';
+	while (*other)
+		*tmp++ = *other++;
+	*tmp = '\0';
+	return (merged);
+}
+
+char	*get_abspath(char *cmd, const char *path)
+{
+	char	*file;
+	char	*dir;
+	int		diff;
+
+	while (*path)
+	{
+		diff = ft_strchr(path, ':') - path;
+		if (diff < 0)
+			diff = ft_strlen(path);
+		dir = ft_substr(path, 0, diff);
+		file = help_slash_merge(dir, cmd);
+		free(dir);
+		if (access(file, X_OK) == 0)
+			return (file);
+		free(file);
+		if (ft_strlen(path) < (size_t)diff)
+			break ;
+		path += diff;
+		if (*path)
+			path++;
+	}
+	perror(ft_strjoin(cmd, ": command not found\n"));
+	exit(EXIT_FAILURE);
+	return (NULL);
 }


### PR DESCRIPTION
Finds absolute and relative paths for system executable functions

- feat: at exit clean `cmd`
- fix: update dispatcher to ignore cmd
- feat: implement exit
- fix: lint files
- feat: implement path finder
- fix: change `execvp` for `execve`

Closes #12
