### PR TITLE
Feature: handle `<`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@
 #    By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/19 22:38:45 by itaureli          #+#    #+#              #
-#    Updated: 2022/05/09 09:35:42 by vwildner         ###   ########.fr        #
+#    Updated: 2022/05/12 02:11:58 by vwildner         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-SRC		= readline.c wip_lexer.c print_error.c execute.c utils.c execute_system.c redir.c
+SRC		= readline.c wip_lexer.c print_error.c execute.c utils.c execute_system.c redir.c utils2.c
 
 SRC_MAIN = $(SRC)
 SRC_MAIN += minishell.c

--- a/includes/builtins.h
+++ b/includes/builtins.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 23:01:22 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/11 20:00:59 by itaureli         ###   ########.fr       */
+/*   Updated: 2022/05/12 03:43:15 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@
 # include <stdlib.h>
 # include <errno.h>
 # include "../libs/libft/libft.h"
+# include <fcntl.h>
 
 typedef enum builtin {
 	ECHO,
@@ -68,5 +69,6 @@ t_list		*lst_find(t_list **list, char *key);
 int			lst_del_node(t_list **list, char *key);
 char		*ms_getenv(t_list *envp[], char *key);
 t_list		*ft_lstnew2(char *content);
+int			read_file(char *filename);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/30 17:04:35 by mfrasson          #+#    #+#             */
-/*   Updated: 2022/05/12 02:15:52 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 03:34:53 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@
 # include <readline/history.h>
 # include <sys/wait.h>
 # include <sys/types.h>
-# include <fcntl.h>
+
 # include "../libs/libft/libft.h"
 # include "../includes/builtins.h"
 # include "./error.h"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/30 17:04:35 by mfrasson          #+#    #+#             */
-/*   Updated: 2022/05/11 20:00:58 by itaureli         ###   ########.fr       */
+/*   Updated: 2022/05/12 02:15:52 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,5 +60,6 @@ int		handle_redirections(t_command *cmd);
 
 /* utilities */
 void	print_err_msg(char *command, char *msg);
-
+char	*solve_absolute_path(t_command *cmd);
+char	**to_array(t_list **list);
 #endif

--- a/libs/builtins/utils.c
+++ b/libs/builtins/utils.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/05 22:27:35 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/10 09:37:12 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 03:34:23 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,4 +102,19 @@ char	*ms_getenv(t_list *envp[], char *key)
 	if (tmp)
 		return (tmp->value);
 	return (NULL);
+}
+
+int	read_file(char *filename)
+{
+	int		fd;
+
+	fd = open(filename, O_RDONLY, 0644);
+	if (fd == -1)
+	{
+		fprintf(stderr, "bash: no such file or directory: %s\n", filename);
+		return (0);
+	}
+	dup2(fd, 0);
+	close(fd);
+	return (fd);
 }

--- a/src/execute_system.c
+++ b/src/execute_system.c
@@ -6,57 +6,11 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/08 02:27:44 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/12 01:30:17 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 02:17:21 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
-
-int	ft_listlen(t_list **list)
-{
-	t_list	*tmp;
-	int		len;
-
-	len = 0;
-	tmp = *list;
-	while (tmp)
-	{
-		tmp = tmp->next;
-		len++;
-	}
-	return (len);
-}
-
-char	**to_array(t_list **list)
-{
-	char	**array;
-	t_list	*tmp;
-	int		i;
-	int		size;
-
-	i = 0;
-	size = ft_listlen(list);
-	tmp = *list;
-	array = (char **)malloc(sizeof(char *) * (size + 1));
-	while (tmp)
-	{
-		array[i++] = tmp->content;
-		tmp = tmp->next;
-	}
-	return (array);
-}
-
-char	*solve_absolute_path(t_command *cmd)
-{
-	char	*first_arg;
-	char	*all_paths;
-
-	first_arg = cmd->argv[0];
-	if (*first_arg == '/' || *first_arg == '.')
-		return (first_arg);
-	all_paths = ms_getenv(cmd->envp, "PATH");
-	return (get_abspath(cmd, first_arg, all_paths));
-}
 
 void	read_file(char *filename)
 {
@@ -74,8 +28,9 @@ void	read_file(char *filename)
 
 void	clear_first_arg(t_command *cmd, int first_arg_pos)
 {
-	int	i;
+	int		i;
 	char	**tmp;
+
 	i = 0;
 	while (cmd->argv[i])
 		i++;
@@ -93,7 +48,6 @@ void	clear_first_arg(t_command *cmd, int first_arg_pos)
 
 int	handle_first_arg(t_command *cmd)
 {
-
 	int		first_arg_pos;
 	char	*filename;
 
@@ -113,7 +67,7 @@ int	handle_first_arg(t_command *cmd)
 	return (0);
 }
 
-static void	execute_child_command(t_command *cmd)
+void	execute_child_command(t_command *cmd)
 {
 	char	*abspath;
 	char	**compat_envp;

--- a/src/execute_system.c
+++ b/src/execute_system.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/08 02:27:44 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/12 03:47:27 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 03:57:38 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ void	clear_first_arg(t_command *cmd, int first_arg_pos)
 	cmd->argc = i;
 }
 
-int	first_is_cat(t_command *cmd)
+int	command_comes_first(t_command *cmd)
 {
 	if (cmd->argc <= 1)
 		return (0);
@@ -49,23 +49,30 @@ int	first_is_cat(t_command *cmd)
 	return (0);
 }
 
+//int redirect_fd(t_command *cmd)
+//{
+//	char	tmp[2];
+
+//	if (ft_isdigit(cmd->argv[0][0]) && cmd->argv[0][1] == '<')
+//	{
+//		tmp[0] = cmd->argv[0][0];
+//		tmp[1] = '\0';
+//		cmd->fd = ft_atoi(tmp);
+//		return (1)
+//	}
+//	return (0);
+//}
+
 int	handle_first_arg(t_command *cmd)
 {
 	int		first_arg_pos;
 	char	*filename;
-	char	tmp[2];
 
 	first_arg_pos = 0;
-	if (first_is_cat(cmd))
+	if (command_comes_first(cmd))
 		return (0);
 	if (cmd->argv[0][0] == '<' && cmd->argv[0][1] == '<')
 		return (0);
-	if (ft_isdigit(cmd->argv[0][0]) && cmd->argv[0][1] == '<')
-	{
-		tmp[0] = cmd->argv[0][0];
-		tmp[1] = '\0';
-		cmd->fd = ft_atoi(tmp);
-	}
 	filename = ft_strchr(cmd->argv[0], '<');
 	if (filename)
 	{

--- a/src/execute_system.c
+++ b/src/execute_system.c
@@ -6,25 +6,11 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/08 02:27:44 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/12 02:43:39 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 03:47:27 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
-
-void	read_file(char *filename)
-{
-	int		fd;
-
-	fd = open(filename, O_RDONLY, 0644);
-	if (fd == -1)
-	{
-		fprintf(stderr, "bash: no such file or directory: %s\n", filename);
-		return ;
-	}
-	dup2(fd, 0);
-	close(fd);
-}
 
 void	clear_first_arg(t_command *cmd, int first_arg_pos)
 {
@@ -46,6 +32,23 @@ void	clear_first_arg(t_command *cmd, int first_arg_pos)
 	cmd->argc = i;
 }
 
+int	first_is_cat(t_command *cmd)
+{
+	if (cmd->argc <= 1)
+		return (0);
+	if (cmd->argv[1][0] == '<' && cmd->argv[1][1] == '\0'
+		&& cmd->argv[2] && cmd->argc == 3)
+	{
+		read_file(cmd->argv[2]);
+		free(cmd->argv[1]);
+		cmd->argv[1] = cmd->argv[2];
+		cmd->argc--;
+		cmd->argv[2] = NULL;
+		return (1);
+	}
+	return (0);
+}
+
 int	handle_first_arg(t_command *cmd)
 {
 	int		first_arg_pos;
@@ -53,6 +56,8 @@ int	handle_first_arg(t_command *cmd)
 	char	tmp[2];
 
 	first_arg_pos = 0;
+	if (first_is_cat(cmd))
+		return (0);
 	if (cmd->argv[0][0] == '<' && cmd->argv[0][1] == '<')
 		return (0);
 	if (ft_isdigit(cmd->argv[0][0]) && cmd->argv[0][1] == '<')

--- a/src/execute_system.c
+++ b/src/execute_system.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/08 02:27:44 by vwildner          #+#    #+#             */
-/*   Updated: 2022/05/12 02:17:21 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 02:43:39 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,10 +50,17 @@ int	handle_first_arg(t_command *cmd)
 {
 	int		first_arg_pos;
 	char	*filename;
+	char	tmp[2];
 
 	first_arg_pos = 0;
 	if (cmd->argv[0][0] == '<' && cmd->argv[0][1] == '<')
 		return (0);
+	if (ft_isdigit(cmd->argv[0][0]) && cmd->argv[0][1] == '<')
+	{
+		tmp[0] = cmd->argv[0][0];
+		tmp[1] = '\0';
+		cmd->fd = ft_atoi(tmp);
+	}
 	filename = ft_strchr(cmd->argv[0], '<');
 	if (filename)
 	{
@@ -62,8 +69,8 @@ int	handle_first_arg(t_command *cmd)
 		if (*filename == '\0')
 			filename = cmd->argv[first_arg_pos++];
 		read_file(filename);
+		clear_first_arg(cmd, first_arg_pos);
 	}
-	clear_first_arg(cmd, first_arg_pos);
 	return (0);
 }
 

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/19 23:07:33 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/11 20:00:57 by itaureli         ###   ########.fr       */
+/*   Updated: 2022/05/11 21:28:16 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,7 @@ void	handle_dollar_sign(t_command *cmd, char *tmp, int i)
 		if (tmp)
 		{
 			free(cmd->argv[i]);
-			cmd->argv[i] = tmp;
+			cmd->argv[i] = ft_strdup(tmp);
 		}
 		else if (len == 1)
 			return ;

--- a/src/readline.c
+++ b/src/readline.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/22 16:31:19 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/11 21:44:10 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 01:37:24 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,16 +41,20 @@ static char	*get_last_slash_arg(char *arg)
 static char	*get_inline_shell_display(t_list *envp[])
 {
 	char	cwd[1025];
+	char	hostname[257];
 	char	*tmp;
 	char	*path;
 	char	*tmp_user;
 
 	getcwd(cwd, 1024);
+	gethostname(hostname, 256);
 	path = get_last_slash_arg(cwd);
 	tmp = ft_strdup("\033[1;31m");
 	tmp_user = ft_strdup(ms_getenv(envp, "USER"));
 	tmp = ft_strjoin(tmp, tmp_user);
-	tmp = ft_strjoin(tmp, "\033[0;36m@minishell \033[0;34m");
+	tmp = ft_strjoin(tmp, "\033[0;36m@");
+	tmp = ft_strjoin(tmp, hostname);
+	tmp = ft_strjoin(tmp, " \033[0;34m");
 	tmp = ft_strjoin(tmp, path);
 	tmp = ft_strjoin(tmp, " ~ $\033[0m ");
 	free(tmp_user);

--- a/src/readline.c
+++ b/src/readline.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   readline.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/22 16:31:19 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/11 19:57:33 by itaureli         ###   ########.fr       */
+/*   Updated: 2022/05/11 21:44:10 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,19 +42,18 @@ static char	*get_inline_shell_display(t_list *envp[])
 {
 	char	cwd[1025];
 	char	*tmp;
-	char	*other;
 	char	*path;
 	char	*tmp_user;
 
 	getcwd(cwd, 1024);
 	path = get_last_slash_arg(cwd);
+	tmp = ft_strdup("\033[1;31m");
 	tmp_user = ft_strdup(ms_getenv(envp, "USER"));
-	tmp = ft_strjoin(tmp_user, "\033[0;31m@minishell ");
-	other = ft_strjoin(tmp, path);
+	tmp = ft_strjoin(tmp, tmp_user);
+	tmp = ft_strjoin(tmp, "\033[0;36m@minishell \033[0;34m");
+	tmp = ft_strjoin(tmp, path);
+	tmp = ft_strjoin(tmp, " ~ $\033[0m ");
 	free(tmp_user);
-	free(tmp);
-	tmp = ft_strjoin(other, " ~ $\033[0m ");
-	free(other);
 	return (tmp);
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/16 18:54:55 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/11 18:26:46 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 02:13:44 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,19 +52,6 @@ char	*help_slash_merge(char const *origin, char const *other)
 	return (merged);
 }
 
-void	print_err_msg(char *command, char *msg)
-{
-	char	*err_msg;
-
-	err_msg = ft_strdup("bash: ");
-	err_msg = ft_strjoin(err_msg, command);
-	err_msg = ft_strjoin(err_msg, ": ");
-	err_msg = ft_strjoin(err_msg, msg);
-	err_msg = ft_strjoin(err_msg, "\n");
-	write(STDERR_FILENO, err_msg, ft_strlen(err_msg));
-	free(err_msg);
-}
-
 char	*get_abspath(t_command *cmd, char *command, const char *path)
 {
 	char	*file;
@@ -92,4 +79,16 @@ char	*get_abspath(t_command *cmd, char *command, const char *path)
 	cmd->status = 127;
 	exit(EXIT_FAILURE);
 	return (NULL);
+}
+
+char	*solve_absolute_path(t_command *cmd)
+{
+	char	*first_arg;
+	char	*all_paths;
+
+	first_arg = cmd->argv[0];
+	if (*first_arg == '/' || *first_arg == '.')
+		return (first_arg);
+	all_paths = ms_getenv(cmd->envp, "PATH");
+	return (get_abspath(cmd, first_arg, all_paths));
 }

--- a/src/utils2.c
+++ b/src/utils2.c
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   utils2.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/08 02:27:44 by vwildner          #+#    #+#             */
+/*   Updated: 2022/05/12 02:13:06 by vwildner         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+void	print_err_msg(char *command, char *msg)
+{
+	char	*err_msg;
+
+	err_msg = ft_strdup("bash: ");
+	err_msg = ft_strjoin(err_msg, command);
+	err_msg = ft_strjoin(err_msg, ": ");
+	err_msg = ft_strjoin(err_msg, msg);
+	err_msg = ft_strjoin(err_msg, "\n");
+	write(STDERR_FILENO, err_msg, ft_strlen(err_msg));
+	free(err_msg);
+}
+
+int	ft_listlen(t_list **list)
+{
+	t_list	*tmp;
+	int		len;
+
+	len = 0;
+	tmp = *list;
+	while (tmp)
+	{
+		tmp = tmp->next;
+		len++;
+	}
+	return (len);
+}
+
+char	**to_array(t_list **list)
+{
+	char	**array;
+	t_list	*tmp;
+	int		i;
+	int		size;
+
+	i = 0;
+	size = ft_listlen(list);
+	tmp = *list;
+	array = (char **)malloc(sizeof(char *) * (size + 1));
+	while (tmp)
+	{
+		array[i++] = tmp->content;
+		tmp = tmp->next;
+	}
+	return (array);
+}

--- a/src/wip_lexer.c
+++ b/src/wip_lexer.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/31 22:26:51 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/09 07:25:30 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/12 00:00:15 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ int	len_token(char *str)
 	len = 0;
 	while (*str
 		&& *str != CHAR_WHITESPACE
-		&& *str != CHAR_PIPE && *str != CHAR_LESSER
+		&& *str != CHAR_PIPE
 		&& *str != CHAR_DOUBLE_QT
 		&& *str != CHAR_SINGLE_QT)
 	{


### PR DESCRIPTION
The shell is now able to handle `fd < filename cmd` and `cmd < filename` commands

- fix: update minishell
- feat: add colors to terminal
- feat: add hostname to shell inline
- fix: remove lesser from lexer
- feat: handle `<`

Todo: 
 - [x] Implement `cmd < file`
 - [x] Implement `fd < file cmd`
 
Mentions #16