### PR TITLE
Examples: Add whitespace parser

### DIFF
--- a/examples/parse_whitespace.c
+++ b/examples/parse_whitespace.c
@@ -1,4 +1,4 @@
-#include "libs/libft/libft.h"
+#include "../libs/libft/libft.h"
 #include <stdio.h>
 
 // cc tests/parse_whitespace.c -g3 libs/libft/*.c
@@ -78,19 +78,22 @@ char **merge_by(char **args, char *delimiters)
 	return (final);
 }
 
+char **parse_whitespace(char *str, char *delims)
+{
+	char	**args;
+	char	**final;
+
+	args = ft_split(str, ' ');
+	final = merge_by(args, delims);
+	return (final);
+}
+
 int main(void)
 {
 	char	str[] = "echo \"hello new world\" this is a \'test case\'";
-	char	**args = ft_split(str, ' ');
-	char	*delims = "\"\'";
-	int j = 0;
-	while (args[j])
-		j++;
-	args[j] = NULL;
-	printf("args are: \n");
-	for (int i = 0; args[i]; i++)
-		printf("args [%i] = %s\n", i, args[i]);
-	char	**final = merge_by(args, delims);
+	char	delims[] = "\"\'";
+	char	**final = parse_whitespace(str, delims);
+
 	printf("final args are: \n");
 	for (int i = 0; final[i]; i++)
 		printf("final[%i] = `%s`\n", i, final[i]);

--- a/examples/parse_whitespace.c
+++ b/examples/parse_whitespace.c
@@ -1,0 +1,98 @@
+#include "libs/libft/libft.h"
+#include <stdio.h>
+
+// cc tests/parse_whitespace.c -g3 libs/libft/*.c
+
+int find_end(char **args, char delim)
+{
+	int	i;
+
+	i = 1;
+	while (args[i] && args[i + 1])
+	{
+		if (ft_strchr(args[i], delim))
+			break ;
+		i++;
+	}
+	return (++i);
+}
+
+char **malloc_mat(char **args)
+{
+	char	**to_malloc;
+	int		i;
+
+	i = 0;
+	while (args[i])
+		i++;
+	to_malloc = malloc(sizeof(char *) * (i + 1));
+	if (!to_malloc)
+		return (NULL);
+	return (to_malloc);
+}
+
+char **join_args(char **args, char delim)
+{
+	int		end_index;
+	int		i;
+	int		j;
+	char	*tmp;
+	char	*other;
+	char	**final;
+
+	final = malloc_mat(args);
+	i = -1;
+	j = 0;
+	while (args[++i])
+	{
+		tmp = ft_strdup(args[i]);
+		if (args[i][0] == delim)
+		{
+			end_index = find_end(&args[i], delim);
+			while (--end_index)
+			{
+				other = ft_strjoin(tmp, " ");
+				free(tmp);
+				tmp = ft_strjoin(other, args[i + 1]);
+				free(other);
+				i++;
+			}
+		}
+		final[j++] = ft_strdup(tmp);
+		free(tmp);
+	}
+	final[j] = NULL;
+	free_matrix(args);
+	return (final);
+}
+
+char **merge_by(char **args, char *delimiters)
+{
+	int	i;
+	char	**final;
+
+	i = 0;
+	final = join_args(args, delimiters[i]);
+	while (delimiters[++i])
+		final = join_args(final, delimiters[i]);
+	return (final);
+}
+
+int main(void)
+{
+	char	str[] = "echo \"hello new world\" this is a \'test case\'";
+	char	**args = ft_split(str, ' ');
+	char	*delims = "\"\'";
+	int j = 0;
+	while (args[j])
+		j++;
+	args[j] = NULL;
+	printf("args are: \n");
+	for (int i = 0; args[i]; i++)
+		printf("args [%i] = %s\n", i, args[i]);
+	char	**final = merge_by(args, delims);
+	printf("final args are: \n");
+	for (int i = 0; final[i]; i++)
+		printf("final[%i] = `%s`\n", i, final[i]);
+	free_matrix(final);
+}


### PR DESCRIPTION
Adds a whitespace parser to help us handle inline parsing
Tested with valgrind for no leaks

## How it works?
- It keeps the tokens from the input.
- These tokens will be needed for handling text or $ENV expansion.

Quick examples:

`"foo bar" baz -> {"foo bar", baz, NULL}`
`foo 'bar baz' -> {foo, 'bar baz', NULL}`
`'foo' "bar baz" -> {'foo', "bar baz", NULL}`
