### PR TITLE
Fix: Move expand args to module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@
 #    By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/19 22:38:45 by itaureli          #+#    #+#              #
-#    Updated: 2022/05/17 20:34:46 by vwildner         ###   ########.fr        #
+#    Updated: 2022/05/20 00:42:48 by vwildner         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-SRC		= readline.c wip_lexer.c print_error.c execute.c utils.c execute_system.c redir.c utils2.c signal.c prompt.c here_doc.c
+SRC		= readline.c wip_lexer.c print_error.c execute.c utils.c execute_system.c redir.c utils2.c signal.c prompt.c here_doc.c expand.c
 
 SRC_MAIN = $(SRC)
 SRC_MAIN += minishell.c

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/30 17:04:35 by mfrasson          #+#    #+#             */
-/*   Updated: 2022/05/15 06:47:54 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/18 19:18:53 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,9 +53,10 @@
 # define READ_END 0
 # define WRITE_END 1
 
+/* parsers */
 int		take_input(char *input_text, t_command *cmd);
 char	**parse_input(char *input_text);
-int		pwd(void);
+void	expand_args(t_command *cmd);
 
 /* executors */
 int		system_exec(t_command *cmd);

--- a/src/expand.c
+++ b/src/expand.c
@@ -1,0 +1,97 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/01/19 23:07:33 by itaureli          #+#    #+#             */
+/*   Updated: 2022/05/18 19:51:28 by vwildner         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+int	handle_status(t_command *cmd, int i)
+{
+	if (cmd->argv[i][1] == '?'
+		&& cmd->argv[i][2] == '\0')
+	{
+		free(cmd->argv[i]);
+		cmd->argv[i] = ft_itoa(cmd->status);
+		return (1);
+	}
+	return (0);
+}
+
+int	handle_quotes(t_command *cmd, int i)
+{
+	size_t	len;
+	char	*tmp;
+
+	tmp = NULL;
+	len = ft_strlen(cmd->argv[i]);
+	if ((cmd->argv[i][0] == CHAR_DOUBLE_QT
+			|| cmd->argv[i][0] == CHAR_SINGLE_QT))
+	{
+		tmp = ft_strtrim(cmd->argv[i], "\"\'");
+		printf("tmp: %s\n", tmp);
+		free(cmd->argv[i]);
+		cmd->argv[i] = ft_strdup(tmp);
+		free(tmp);
+		return (1);
+	}
+	return (0);
+}
+
+void	handle_dollar_sign(t_command *cmd, char *tmp, int i)
+{
+	size_t	len;
+
+	len = ft_strlen(cmd->argv[i]);
+	if (cmd->argv[i][0] == '$')
+	{
+		if (handle_status(cmd, i))
+			return ;
+		tmp = ms_getenv(cmd->envp, &cmd->argv[i][1]);
+		if (tmp)
+		{
+			free(cmd->argv[i]);
+			cmd->argv[i] = ft_strdup(tmp);
+		}
+		else if (len == 1)
+			return ;
+		else
+		{
+			free(cmd->argv[i]);
+			cmd->argv[i] = ft_strdup("");
+		}
+	}
+}
+
+void	expand_args(t_command *cmd)
+{
+	int		i;
+	char	*tmp;
+	size_t	len;
+
+	i = -1;
+	tmp = NULL;
+	while (cmd->argv[++i])
+	{
+		if (handle_quotes(cmd, i))
+			continue ;
+		handle_dollar_sign(cmd, tmp, i);
+		if (cmd->argv[i][0] == '~')
+		{
+			tmp = getenv("HOME");
+			len = ft_strlen(cmd->argv[i]);
+			free(cmd->argv[i]);
+			if (len > 1)
+				cmd->argv[i] = ft_strjoin(tmp, &cmd->argv[i][1]);
+			else
+				cmd->argv[i] = ft_strdup(tmp);
+		}
+	}
+	cmd->argc = i;
+}

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/19 23:07:33 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/18 19:51:28 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/19 17:58:28 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ int	handle_quotes(t_command *cmd, int i)
 	tmp = NULL;
 	len = ft_strlen(cmd->argv[i]);
 	if ((cmd->argv[i][0] == CHAR_DOUBLE_QT
-			|| cmd->argv[i][0] == CHAR_SINGLE_QT))
+		|| cmd->argv[i][0] == CHAR_SINGLE_QT))
 	{
 		tmp = ft_strtrim(cmd->argv[i], "\"\'");
 		printf("tmp: %s\n", tmp);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,73 +6,11 @@
 /*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/19 23:07:33 by itaureli          #+#    #+#             */
-/*   Updated: 2022/05/15 05:45:19 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/05/19 01:01:58 by vwildner         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
-
-int	handle_status(t_command *cmd, int i)
-{
-	if (cmd->argv[i][1] == '?'
-		&& cmd->argv[i][2] == '\0')
-	{
-		free(cmd->argv[i]);
-		cmd->argv[i] = ft_itoa(cmd->status);
-		return (1);
-	}
-	return (0);
-}
-
-void	handle_dollar_sign(t_command *cmd, char *tmp, int i)
-{
-	size_t	len;
-
-	len = ft_strlen(cmd->argv[i]);
-	if (cmd->argv[i][0] == '$')
-	{
-		if (handle_status(cmd, i))
-			return ;
-		tmp = ms_getenv(cmd->envp, &cmd->argv[i][1]);
-		if (tmp)
-		{
-			free(cmd->argv[i]);
-			cmd->argv[i] = ft_strdup(tmp);
-		}
-		else if (len == 1)
-			return ;
-		else
-		{
-			free(cmd->argv[i]);
-			cmd->argv[i] = ft_strdup("");
-		}
-	}
-}
-
-void	expand_args(t_command *cmd)
-{
-	int		i;
-	char	*tmp;
-	size_t	len;
-
-	i = -1;
-	tmp = NULL;
-	while (cmd->argv[++i])
-	{
-		handle_dollar_sign(cmd, tmp, i);
-		if (cmd->argv[i][0] == '~')
-		{
-			tmp = getenv("HOME");
-			len = ft_strlen(cmd->argv[i]);
-			free(cmd->argv[i]);
-			if (len > 1)
-				cmd->argv[i] = ft_strjoin(tmp, &cmd->argv[i][1]);
-			else
-				cmd->argv[i] = ft_strdup(tmp);
-		}
-	}
-	cmd->argc = i;
-}
 
 int	main(int argc, char *argv[], char *envp[])
 {


### PR DESCRIPTION
Moving expand args to its own module to enable adding it to unit tests.
