### PR TITLE
feat: add reachable from readline into supp

### DIFF
--- a/local.supp
+++ b/local.supp
@@ -9,16 +9,17 @@
 {
    <Readline>
    Memcheck:Leak
-   match-leak-kinds: reachable
+   match-leak-kinds: definite
    ...
    fun:readline
    ...
 }
 {
-   <AddHistory>
+   <Readline/AddHistory>
    Memcheck:Leak
    match-leak-kinds: reachable
-   ...
+   fun:malloc
+   fun:xmalloc
    fun:add_history
    ...
 }

--- a/local.supp
+++ b/local.supp
@@ -7,6 +7,14 @@
    ...
 }
 {
+   <Readline>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:readline
+   ...
+}
+{
    <AddHistory>
    Memcheck:Leak
    match-leak-kinds: reachable


### PR DESCRIPTION
Adicionei reachable ao supp

creio que estamos correndo atras de still reachable desnecessário, minha tese:
https://valgrind.org/docs/manual/faq.html#faq.deflost
""still reachable" means your program is probably ok -- it didn't free some memory it could have. This is quite common and often reasonable. Don't use --show-reachable=yes if you don't want to see these reports."

https://stackoverflow.com/questions/55196451/gnu-readline-enormous-memory-leak
https://cboard.cprogramming.com/c-programming/136521-memory-leak-readline.html#post1016760
https://stackoverflow.com/a/3857638

Comando indicado pelo @LucasKuhn

Aí chamando ele no valgrind com um monte de flags 

```bash
valgrind --suppressions=./local.supp --leak-check=full \
    --show-leak-kinds=all --track-fds=yes --trace-children=yes ./minishell
```
Uma que foi massa pra gente resolver leaks foi abrir o próprio bash no Valgrind 
```bash
valgrind --suppressions=./local.supp --leak-check=full --show-leak-kinds=all --track-fds=yes --trace-children=yes bash
```

Nos prints eu testei vários minishell de galera que ja entregou e todos tem o mesmo still reachable, eu falei com o Welton na vila aqui também e tudo que vimos foi do readline

![image](https://user-images.githubusercontent.com/11761170/173190991-cf76889b-ad6f-43c6-8f15-13125327f87d.png)
![image](https://user-images.githubusercontent.com/11761170/173190995-5233aedc-5d41-4c70-b511-58f7c5cfa911.png)
![image](https://user-images.githubusercontent.com/11761170/173190998-825497b7-1a19-47ee-8811-5e13384b4240.png)
![image](https://user-images.githubusercontent.com/11761170/173191000-e258acfa-c1c0-434f-80b2-87d49109565b.png)
![image](https://user-images.githubusercontent.com/11761170/173191004-f19851c2-a0d5-4edd-823e-4eb35af07f08.png)
