### PR TITLE
fix: validate exit many args

### DIFF
--- a/libs/builtins/builtins.c
+++ b/libs/builtins/builtins.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vwildner <vwildner@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/01 22:23:50 by vwildner          #+#    #+#             */
-/*   Updated: 2022/06/07 18:17:29 by vwildner         ###   ########.fr       */
+/*   Updated: 2022/06/11 17:02:03 by itaureli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,11 @@ int	builtins_env(t_command *cmd)
 
 int	builtins_exit(t_command *cmd)
 {
+	if (cmd->argc > 2)
+	{
+		write(STDERR_FILENO, "exit: too many arguments\n", 26);
+		return (0);
+	}
 	if (cmd->argc > 1)
 		exit(ft_atoi(cmd->argv[1]));
 	else

--- a/libs/builtins/builtins.c
+++ b/libs/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/01 22:23:50 by vwildner          #+#    #+#             */
-/*   Updated: 2022/06/11 17:02:03 by itaureli         ###   ########.fr       */
+/*   Updated: 2022/06/11 17:18:50 by itaureli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,11 +32,8 @@ int	builtins_env(t_command *cmd)
 int	builtins_exit(t_command *cmd)
 {
 	if (cmd->argc > 2)
-	{
 		write(STDERR_FILENO, "exit: too many arguments\n", 26);
-		return (0);
-	}
-	if (cmd->argc > 1)
+	else if (cmd->argc > 1)
 		exit(ft_atoi(cmd->argv[1]));
 	else
 		exit(0);


### PR DESCRIPTION
Talking with other cadetes I've found that our exit command needed a validation.

I've fixed exit with multiple arguments to work like bash:

bash:
```bash
exit 100 128
bash: exit: too many arguments
```

Our minishell without fix:
```bash
exit 100 128
# exit from minishell
echo $?
100
```
I've compared with bash and not sh because of this on PDF, sh has a different behavior:
![image](https://user-images.githubusercontent.com/11761170/173203423-3cc4772b-87cd-4b38-9aed-1dffe07d4414.png)


We need to pay attention into exit codes:
![image](https://user-images.githubusercontent.com/11761170/173203354-c7617b45-208d-4078-8b45-fe5a855919f7.png)
